### PR TITLE
Metadata objects creation for PDF/A-1 fix

### DIFF
--- a/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/cos/PBCosDict.java
+++ b/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/cos/PBCosDict.java
@@ -113,19 +113,19 @@ public class PBCosDict extends PBCosObject implements CosDict {
      * Get XMP metadata if it is present
      */
     private List<PDMetadata> getMetadata() {
-        if (this.flavour == null || this.flavour.getPart() == null || this.flavour.getPart().getPartNumber() != 1) {
-            COSDictionary dictionary = (COSDictionary) this.baseObject;
-            COSBase meta = dictionary.getDictionaryObject(COSName.METADATA);
-            COSName type = dictionary.getCOSName(COSName.TYPE);
-            if (meta != null && meta instanceof COSStream
-                    && type != COSName.CATALOG) {
-                ArrayList<PDMetadata> pdMetadatas = new ArrayList<>(MAX_NUMBER_OF_ELEMENTS);
-                org.apache.pdfbox.pdmodel.common.PDMetadata md = new org.apache.pdfbox.pdmodel.common.PDMetadata(
-                        (COSStream) meta);
-                pdMetadatas.add(new PBoxPDMetadata(md, Boolean.FALSE, document, flavour));
-                return pdMetadatas;
-            }
+
+        COSDictionary dictionary = (COSDictionary) this.baseObject;
+        COSBase meta = dictionary.getDictionaryObject(COSName.METADATA);
+        COSName type = dictionary.getCOSName(COSName.TYPE);
+        if (meta != null && meta instanceof COSStream
+                && type != COSName.CATALOG) {
+            ArrayList<PDMetadata> pdMetadatas = new ArrayList<>(MAX_NUMBER_OF_ELEMENTS);
+            org.apache.pdfbox.pdmodel.common.PDMetadata md = new org.apache.pdfbox.pdmodel.common.PDMetadata(
+                    (COSStream) meta);
+            pdMetadatas.add(new PBoxPDMetadata(md, Boolean.FALSE, document, flavour));
+            return pdMetadatas;
         }
+
         return Collections.emptyList();
     }
 }

--- a/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/PBoxPDMetadata.java
+++ b/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/PBoxPDMetadata.java
@@ -87,7 +87,7 @@ public class PBoxPDMetadata extends PBoxPDObject implements PDMetadata {
                 VeraPDFMeta metadata = VeraPDFMeta.parse(stream.getUnfilteredStream());
                 if (isMainMetadata) {
                     xmp.add(new AXLMainXMPPackage(metadata, true, this.flavour));
-                } else {
+                } else if (this.flavour == null || this.flavour.getPart() == null || this.flavour.getPart().getPartNumber() != 1) {
                     COSStream mainStream = mainMetadata.getStream();
                     VeraPDFXMPNode mainExtensionNode = null;
                     if (mainStream != null) {
@@ -99,7 +99,11 @@ public class PBoxPDMetadata extends PBoxPDObject implements PDMetadata {
             }
         } catch (XMPException | IOException e) {
             LOGGER.debug("Problems with parsing metadata. " + e.getMessage(), e);
-            xmp.add(new AXLXMPPackage(null, false, null, this.flavour));
+            if (isMainMetadata) {
+                xmp.add(new AXLMainXMPPackage(null, false, this.flavour));
+            } else if (this.flavour == null || this.flavour.getPart() == null || this.flavour.getPart().getPartNumber() != 1) {
+                xmp.add(new AXLXMPPackage(null, false, null, this.flavour));
+            }
         }
         return xmp;
     }


### PR DESCRIPTION
Changed validation of metadata for pdfa-1 from not validating all non-document level metadata dictionaries to not validating all non-document level metadata packages.