### PR TITLE
Fixed links and implemented a property from Type0 font

### DIFF
--- a/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/PBoxPDAnnot.java
+++ b/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/PBoxPDAnnot.java
@@ -319,6 +319,8 @@ public class PBoxPDAnnot extends PBoxPDObject implements PDAnnot {
 				addContentStreamsFromAppearanceEntry(downAppearanceBase, appearances);
 				addContentStreamsFromAppearanceEntry(rolloverAppearanceBase, appearances);
 				this.appearance = Collections.unmodifiableList(appearances);
+			} else {
+				this.appearance = Collections.emptyList();
 			}
 		} else {
 			this.appearance = Collections.emptyList();

--- a/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/font/PBoxPDType0Font.java
+++ b/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/font/PBoxPDType0Font.java
@@ -82,9 +82,17 @@ public class PBoxPDType0Font extends PBoxPDFont implements PDType0Font {
 		return Boolean.FALSE;
 	}
 
-	// TODO : implement me
 	@Override
 	public Boolean getisSupplementCompatible() {
+		org.apache.pdfbox.pdmodel.font.PDCIDFont descendantFont =
+				((org.apache.pdfbox.pdmodel.font.PDType0Font) this.pdFontLike).getDescendantFont();
+		if (descendantFont != null) {
+			PDCIDSystemInfo cidSystemInfo = descendantFont.getCIDSystemInfo();
+			CMap currentCMap = ((org.apache.pdfbox.pdmodel.font.PDType0Font) this.pdFontLike).getCMap();
+			if (cidSystemInfo != null && currentCMap != null) {
+				return Boolean.valueOf(cidSystemInfo.getSupplement() >= currentCMap.getSupplement());
+			}
+		}
 		return Boolean.FALSE;
 	}
 


### PR DESCRIPTION
Fixed issue with wrong creation of appearance stream links for annotations in case of missed appearance streams. Implemented property isSupplementCompatible from Type0 font