### PR TITLE
REL - Development versions v1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: required
 dist: trusty
 
 jdk:
-  - openjdk7
   - openjdk8
-#  - oraclejdk7
   - oraclejdk8
 
 branches:

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.verapdf</groupId>
     <artifactId>verapdf-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.12.2</version>
   </parent>
 
   <groupId>org.verapdf</groupId>
@@ -81,8 +81,8 @@
   <properties>
     <sonar.jacoco.itReportPath>${project.basedir}/../target/jacoco-it.exec</sonar.jacoco.itReportPath>
     <sonar.language>java</sonar.language>
-    <verapdf.library.version>[1.10.0,1.11.0)</verapdf.library.version>
-    <verapdf.model.version>[1.10.0,1.11.0)</verapdf.model.version>
+    <verapdf.library.version>[1.11.0,1.12.0)</verapdf.library.version>
+    <verapdf.model.version>[1.11.0,1.12.0)</verapdf.model.version>
     <verapdf.pdfbox.version>[2.0.0,2.1.0)</verapdf.pdfbox.version>
     <verapdf.xmp.version>[0.12.0,0.13.0)</verapdf.xmp.version>
   </properties>
@@ -123,13 +123,13 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
-        <version>1.54</version>
+        <version>1.58</version>
       </dependency>
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.54</version>
+        <version>1.58</version>
       </dependency>
 
       <dependency>
@@ -138,7 +138,6 @@
         <version>4.12</version>
         <scope>test</scope>
       </dependency>
-
 
       <dependency>
         <groupId>log4j</groupId>
@@ -176,7 +175,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>


### PR DESCRIPTION
- bumped minor version -> 1.11 for development;
- updated library and model dependencies;
- updated bouncy castle dependency to 1.58;
- updated parent to 1.12.2 for Java 8; and
- minor tidy to plugin management.