### PR TITLE
FIX - Java 11 javax.xml.bind dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
 
 before_install:
   - sudo apt-get install jq
-  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
+  - wget -O ~/codacy-coverage-reporter-assembly-latest.jar http://resources.openpreservation.org/codacy-coverage-reporter-assembly-latest.jar
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/pdfbox-feature-reporting/pom.xml
+++ b/pdfbox-feature-reporting/pom.xml
@@ -23,35 +23,55 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
- <parent>
-  <artifactId>verapdf-pdfbox-validation</artifactId>
-  <groupId>org.verapdf</groupId>
-  <version>1.13.0-SNAPSHOT</version>
- </parent>
- <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>verapdf-pdfbox-validation</artifactId>
+    <groupId>org.verapdf</groupId>
+    <version>1.13.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
 
- <artifactId>pdfbox-feature-reporting</artifactId>
- <name>veraPDF PDF Box Features Reporting</name>
- <description>Reports features extracted from a PDF document.</description>
+  <artifactId>pdfbox-feature-reporting</artifactId>
+  <name>veraPDF PDF Box Features Reporting</name>
+  <description>Reports features extracted from a PDF document.</description>
 
- <dependencies>
-  <dependency>
-   <groupId>org.verapdf.pdfbox</groupId>
-   <artifactId>pdfbox</artifactId>
-  </dependency>
-  <dependency>
-   <groupId>junit</groupId>
-   <artifactId>junit</artifactId>
-   <scope>test</scope>
-  </dependency>
-  <dependency>
-   <groupId>org.verapdf</groupId>
-   <artifactId>core</artifactId>
-  </dependency>
-  <dependency>
-   <groupId>log4j</groupId>
-   <artifactId>log4j</artifactId>
-  </dependency>
+  <dependencies>
+
+    <dependency>
+      <groupId>org.verapdf.pdfbox</groupId>
+      <artifactId>pdfbox</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.verapdf</groupId>
+      <artifactId>core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+    </dependency>
+
  </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,24 @@
       </dependency>
 
       <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>2.3.0.1</version>
+      </dependency>
+
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.12</version>


### PR DESCRIPTION
- added missing dependencies to main `pom.xml` dependency management section; and
- added required dependencies to `pdfbox-feature-reporting/pom.xml`.