### PR TITLE
PDF/UA validation. Add method gethasCorrectAlt to PBoxPDMediaClip

### DIFF
--- a/pdfbox-validation-model/src/main/java/org/verapdf/model/ModelParser.java
+++ b/pdfbox-validation-model/src/main/java/org/verapdf/model/ModelParser.java
@@ -61,6 +61,8 @@ public final class ModelParser implements PDFAParser {
 	private static final ComponentDetails details = Components.veraDetails(id, "PDFBox Parser",
 			pdfBoxReleaseDetails.getVersion(), "veraPDF PDFBox based model parser.");
 
+	private static final String PDFUA_PREFIX = "ua";
+
 	private static final Logger logger = Logger.getLogger(ModelParser.class);
 
 	private PDDocument document;
@@ -114,7 +116,17 @@ public final class ModelParser implements PDFAParser {
 			VeraPDFMeta veraPDFMeta = VeraPDFMeta.parse(is);
 			Integer identificationPart = veraPDFMeta.getIdentificationPart();
 			String identificationConformance = veraPDFMeta.getIdentificationConformance();
-			PDFAFlavour pdfaFlavour = PDFAFlavour.byFlavourId(identificationPart + identificationConformance);
+			String prefix = "";
+			if (identificationPart == null && identificationConformance == null) {
+				identificationPart = veraPDFMeta.getUAIdentificationPart();
+				if (identificationPart != null) {
+					prefix = PDFUA_PREFIX;
+				}
+			}
+			if (identificationConformance == null) {
+				identificationConformance = "";
+			}
+			PDFAFlavour pdfaFlavour = PDFAFlavour.byFlavourId(prefix + identificationPart + identificationConformance);
 			// TODO: remove that logic after updating NO_FLAVOUR into base pdf validation flavour
 			if (pdfaFlavour == PDFAFlavour.NO_FLAVOUR) {
 				return defaultFlavour;

--- a/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/external/PBoxEmbeddedFile.java
+++ b/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/external/PBoxEmbeddedFile.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 
 import org.apache.log4j.Logger;
 import org.apache.pdfbox.cos.COSBase;
-import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSStream;
 import org.verapdf.model.ModelParser;

--- a/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/actions/PBoxPDMediaClip.java
+++ b/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/actions/PBoxPDMediaClip.java
@@ -60,6 +60,25 @@ public class PBoxPDMediaClip extends PBoxPDObject implements PDMediaClip {
         }
         return list.stream()
                 .filter(Objects::nonNull)
-                .collect(Collectors.joining(" "));
+                .collect(Collectors.joining(""));
+    }
+
+    @Override
+    public Boolean gethasCorrectAlt() {
+        COSBase object = ((COSDictionary)simplePDObject).getDictionaryObject(COSName.ALT);
+        if (!(object instanceof COSArray)) {
+            return false;
+        }
+        COSArray array = (COSArray)object;
+        if (array.size() % 2 != 0) {
+            return false;
+        }
+        for (int i = 0; i < array.size(); i++) {
+            COSBase elem = array.get(i);
+            if (!(elem instanceof COSString) || (i % 2 == 1 && ((COSString)elem).getString().isEmpty())) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/pdfbox-validation-model/src/test/java/org/verapdf/model/impl/pb/cos/PBCosTrailerTest.java
+++ b/pdfbox-validation-model/src/test/java/org/verapdf/model/impl/pb/cos/PBCosTrailerTest.java
@@ -31,6 +31,7 @@ import org.verapdf.model.baselayer.Object;
 import org.verapdf.model.coslayer.CosIndirect;
 import org.verapdf.model.coslayer.CosTrailer;
 import org.verapdf.model.impl.BaseTest;
+import org.verapdf.model.pdlayer.PDEncryption;
 
 import java.io.IOException;
 import java.util.List;
@@ -64,6 +65,13 @@ public class PBCosTrailerTest extends BaseTest {
         List<? extends Object> catalog = actual.getLinkedObjects(PBCosTrailer.CATALOG);
         Assert.assertEquals(catalog.size(), 1);
         Assert.assertTrue(catalog.get(0) instanceof CosIndirect);
+    }
+
+    @Test
+    public void testEncryptLink() {
+        List<? extends Object> encrypt = actual.getLinkedObjects(PBCosTrailer.ENCRYPT);
+        Assert.assertEquals(encrypt.size(), 1);
+        Assert.assertTrue(encrypt.get(0) instanceof PDEncryption);
     }
 
     @Test


### PR DESCRIPTION
Required: https://github.com/veraPDF/veraPDF-model/pull/214