### PR TITLE
PDF/UA validation. Fix method getisUniqueSemanticParent

### DIFF
--- a/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/containers/StaticContainers.java
+++ b/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/containers/StaticContainers.java
@@ -47,6 +47,8 @@ public class StaticContainers {
 	//SEHn
 	private static ThreadLocal<Integer> lastHeadingNestingLevel = new ThreadLocal<>();
 
+	//PDXForm
+	private static final ThreadLocal<Set<COSObjectKey>> xFormKeysSet = new ThreadLocal<>();
 
 	public static void clearAllContainers() {
 		getSeparations().clear();
@@ -54,6 +56,7 @@ public class StaticContainers {
 		getCachedColorSpaces().clear();
 		getFileSpecificationKeys().clear();
 		noteIDSet.set(new HashSet<>());
+		xFormKeysSet.set(new HashSet<>());
 		lastHeadingNestingLevel.set(0);
 	}
 
@@ -110,6 +113,15 @@ public class StaticContainers {
 
 	public static void setFileSpecificationKeys(Set<COSObjectKey> fileSpecificationKeys) {
 		StaticContainers.fileSpecificationKeys.set(fileSpecificationKeys);
+	}
+
+	public static Set<COSObjectKey> getXFormKeysSet() {
+		checkForNull(xFormKeysSet, new HashSet<COSObjectKey>());
+		return xFormKeysSet.get();
+	}
+
+	public static void setXFormKeysSet(Set<COSObjectKey> xFormKeysSet) {
+		StaticContainers.xFormKeysSet.set(xFormKeysSet);
 	}
 
 	private static void checkForNull(ThreadLocal variable, Object object) {

--- a/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/images/PBoxPDXForm.java
+++ b/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/images/PBoxPDXForm.java
@@ -24,9 +24,11 @@ import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSStream;
+import org.apache.pdfbox.cos.COSObjectKey;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.verapdf.model.baselayer.Object;
+import org.verapdf.model.impl.pb.containers.StaticContainers;
 import org.verapdf.model.impl.pb.pd.PBoxPDContentStream;
 import org.verapdf.model.impl.pb.pd.PBoxPDGroup;
 import org.verapdf.model.pdlayer.PDContentStream;
@@ -91,8 +93,26 @@ public class PBoxPDXForm extends PBoxPDXObject implements PDXForm {
 	}
 
 	@Override
-	public Boolean getisUniqueSemanticParent() {
+	public String getID() {
 		return null;
+	}
+
+	@Override
+	public Boolean getisUniqueSemanticParent() {
+		COSBase pageObject = this.simplePDObject.getCOSObject();
+		if (pageObject instanceof COSDictionary && !((COSDictionary) pageObject).containsKey(COSName.STRUCT_PARENTS)) {
+			return true;
+		}
+		COSObjectKey key = this.simplePDObject.getCOSObject().getKey();
+		if (key == null) {
+			return true;
+		}
+		if (StaticContainers.getXFormKeysSet().contains(key)) {
+			return false;
+		}
+		StaticContainers.getXFormKeysSet().add(key);
+		return true;
+
 	}
 
 	@Override

--- a/pdfbox-validation-model/src/test/java/org/verapdf/model/impl/pb/pd/images/PBoxPDXFormTest.java
+++ b/pdfbox-validation-model/src/test/java/org/verapdf/model/impl/pb/pd/images/PBoxPDXFormTest.java
@@ -46,7 +46,7 @@ public class PBoxPDXFormTest extends PBoxPDAbstractXObjectTest {
 	@BeforeClass
 	public static void setUp() throws IOException, URISyntaxException {
 		expectedType = TYPES.contains(PBoxPDXForm.X_FORM_TYPE) ? PBoxPDXForm.X_FORM_TYPE : null;
-		expectedID = "39 0 obj PDXForm";
+		expectedID = null;
 
 		setUp(FILE_RELATIVE_PATH);
 		PDResources pageResources = document.getPage(0).getResources();


### PR DESCRIPTION
according to the rule 7.20-2