### PR TITLE
PDF/A-4e validation. Fix method getSubtype in PBoxPD3DStream

### DIFF
--- a/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/PBoxPD3DStream.java
+++ b/pdfbox-validation-model/src/main/java/org/verapdf/model/impl/pb/pd/PBoxPD3DStream.java
@@ -53,6 +53,7 @@ public class PBoxPD3DStream extends PBoxPDObject implements PD3DStream {
 
 	@Override
 	public String getSubtype() {
-		return ((COSStream)simplePDObject).getString(COSName.SUBTYPE);
+		COSName subtype = ((COSStream)simplePDObject).getCOSName(COSName.SUBTYPE);
+		return subtype == null ? null : subtype.getName();
 	}
 }


### PR DESCRIPTION
rule 6.1.6.1-03